### PR TITLE
feat: support monorepos, simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ npx expo install @nozbe/watermelondb @babel/plugin-proposal-decorators
 
 ```js
 module.exports = function (api) {
-	api.cache(true);
-	return {
-		presets: ['babel-preset-expo'],
-		plugins: [['@babel/plugin-proposal-decorators', { legacy: true }]],
-	};
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [["@babel/plugin-proposal-decorators", { legacy: true }]],
+  };
 };
 ```
 
@@ -36,37 +36,36 @@ npx expo install @skam22/watermelondb-expo-plugin
 
 #### Modify your `app.json` plugin block to add the following:
 
-```javascript
+```json
 {
-	"expo": {
-		...
-		"plugins": [
-			[
-				"expo-build-properties",
-				{
-					"android": {
-						"kotlinVersion": "1.6.10",
-						"compileSdkVersion": 33,
-						"targetSdkVersion": 33,
-						"packagingOptions": {
-							"pickFirst": ["**/libc++_shared.so"]
-						}
-					},
-					"ios": {
-						"extraPods": [
-                          {
-                            "name": "simdjson",
-                            "configurations": ["Debug", "Release"],
-                            "path": "path_to/node_modules/@nozbe/simdjson",
-                            "modular_headers": true
-                          }
-                        ]
-					},
-				}
-			],
-			"@skam22/watermelondb-expo-plugin"
-		],
-	}
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "kotlinVersion": "1.6.10",
+            "compileSdkVersion": 33,
+            "targetSdkVersion": 33,
+            "packagingOptions": {
+              "pickFirst": ["**/libc++_shared.so"]
+            }
+          },
+          "ios": {
+            "extraPods": [
+              {
+                "name": "simdjson",
+                "configurations": ["Debug", "Release"],
+                "path": "path_to/node_modules/@nozbe/simdjson",
+                "modular_headers": true
+              }
+            ]
+          }
+        }
+      ],
+      "@skam22/watermelondb-expo-plugin"
+    ]
+  }
 }
 ```
 
@@ -90,13 +89,13 @@ If the structure/contents/spelling of these default files change in future versi
 
 For example, `android/settings.gradle` references the line:
 
-```js
+```groovy
 include ':app'
 ```
 
 `android/app/build.gradle` references the line:
 
-```js
+```groovy
 def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,17 @@ npx expo install @skam22/watermelondb-expo-plugin
 						"packagingOptions": {
 							"pickFirst": ["**/libc++_shared.so"]
 						}
-					}
+					},
+					"ios": {
+						"extraPods": [
+                          {
+                            "name": "simdjson",
+                            "configurations": ["Debug", "Release"],
+                            "path": "path_to/node_modules/@nozbe/simdjson",
+                            "modular_headers": true
+                          }
+                        ]
+					},
 				}
 			],
 			"@skam22/watermelondb-expo-plugin"
@@ -78,24 +88,7 @@ The modifications to the native files are all accomplished by reading the existi
 
 If the structure/contents/spelling of these default files change in future versions of react native or expo in any way, these plugin modifications will fail.
 
-For example, the Podfile modification inserts
-
-```js
-pod 'simdjson', path: '../node_modules/@nozbe/simdjson', modular_headers: true
-
-```
-
-by referencing the line:
-
-```js
-flipper_config = FlipperConfiguration.disabled;
-```
-
-If the referenced line doesn't exist or is modified in any way, the iOS plugin will fail.
-
-The `@nozbe/watermelondb` android specific installation steps are accomplished similarly.
-
-`android/settings.gradle` references the line:
+For example, `android/settings.gradle` references the line:
 
 ```js
 include ':app'
@@ -112,17 +105,3 @@ def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
 ```
 # Add any project specific keep options here:
 ```
-
-`MainApplication.java` references the line:
-
-```js
-import java.util.List;
-```
-
-and also searches for the line that includes this text, and then inserts the JSIModulePackage Override 3 lines later:
-
-```js
-isHermesEnabled();
-```
-
-This approach is not future proof and probably not backwards compatible either, though I haven't specifically checked the contents of the default files for older versions of react native or expo.

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,93 +1,107 @@
-import { ConfigPlugin, withDangerousMod, withPlugins, withMainApplication } from '@expo/config-plugins';
-import { addImports } from '@expo/config-plugins/build/android/codeMod';
-import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
-import fs from 'fs-extra';
-import path from 'path';
+import {
+  ConfigPlugin,
+  withDangerousMod,
+  withPlugins,
+  withMainApplication,
+} from "@expo/config-plugins";
+import { addImports } from "@expo/config-plugins/build/android/codeMod";
+import { mergeContents } from "@expo/config-plugins/build/utils/generateCode";
+import fs from "fs-extra";
+import path from "path";
 
-const readFileAsync = async (path: string) => fs.promises.readFile(path, 'utf-8');
+const readFileAsync = async (path: string) =>
+  fs.promises.readFile(path, "utf-8");
 const writeFileAsync = async (path: string, content: string) =>
-	fs.promises.writeFile(path, content, 'utf-8');
-
+  fs.promises.writeFile(path, content, "utf-8");
 
 const androidPlugin: ConfigPlugin = (c) =>
-	withDangerousMod(c, [
-		'android',
-		async (config) => {
-			const { platformProjectRoot } = config.modRequest;
-			/**
-			 * JSI Step 1: make sure you have NDK installed (version 23.1.7779620 has been tested to work)
-			 */
+  withDangerousMod(c, [
+    "android",
+    async (config) => {
+      const { platformProjectRoot } = config.modRequest;
+      /**
+       * JSI Step 1: make sure you have NDK installed (version 23.1.7779620 has been tested to work)
+       */
 
-			/**
-			 * JSI Step 2: create new project in android/settings.gradle
-			 */
-			const settingsFile = path.join(platformProjectRoot, 'settings.gradle');
-			const settingsContents = await readFileAsync(settingsFile);
-			const projectDir = `new File(["node", "--print", "require.resolve('@nozbe/watermelondb/package.json')"].execute(null, rootDir).text.trim(), "../native/android-jsi")`;
+      /**
+       * JSI Step 2: create new project in android/settings.gradle
+       */
+      const settingsFile = path.join(platformProjectRoot, "settings.gradle");
+      const settingsContents = await readFileAsync(settingsFile);
+      const projectDir = `new File(["node", "--print", "require.resolve('@nozbe/watermelondb/package.json')"].execute(null, rootDir).text.trim(), "../native/android-jsi")`;
 
-			await writeFileAsync(
-				settingsFile,
-				mergeContents({
-					tag: `@nozbe/watermelondb/jsi-installation`,
-					src: settingsContents,
-					newSrc: `
+      await writeFileAsync(
+        settingsFile,
+        mergeContents({
+          tag: `@nozbe/watermelondb/jsi-installation`,
+          src: settingsContents,
+          newSrc: `
 		include ':watermelondb-jsi'
 		project(':watermelondb-jsi').projectDir = ${projectDir}`,
-					offset: 0,
-					comment: '//',
-					anchor: "include ':app'",
-				}).contents
-			);
+          offset: 0,
+          comment: "//",
+          anchor: "include ':app'",
+        }).contents,
+      );
 
-			/**
-			 * JSI Step 3: add project created from step 2 as a dependency to the app
-			 */
-			const buildFile = path.join(platformProjectRoot, 'app/build.gradle');
-			const buildContents = await readFileAsync(buildFile);
-			await writeFileAsync(
-				buildFile,
-				mergeContents({
-					tag: `@nozbe/watermelondb/jsi-installation`,
-					src: buildContents,
-					newSrc: `implementation project(':watermelondb-jsi')`,
-					offset: 4,
-					comment: '//',
-					anchor: /def isGifEnabled = \(findProperty\('expo\.gif\.enabled'\) \?: ""\) == "true";/,
-				}).contents
-			);
+      /**
+       * JSI Step 3: add project created from step 2 as a dependency to the app
+       */
+      const buildFile = path.join(platformProjectRoot, "app/build.gradle");
+      const buildContents = await readFileAsync(buildFile);
+      await writeFileAsync(
+        buildFile,
+        mergeContents({
+          tag: `@nozbe/watermelondb/jsi-installation`,
+          src: buildContents,
+          newSrc: `implementation project(':watermelondb-jsi')`,
+          offset: 4,
+          comment: "//",
+          anchor:
+            /def isGifEnabled = \(findProperty\('expo\.gif\.enabled'\) \?: ""\) == "true";/,
+        }).contents,
+      );
 
-			/**
-			 * JSI Step 4: add proguard rules
-			 */
-			const proguardFile = path.join(platformProjectRoot, 'app/proguard-rules.pro');
-			const proguardContents = await readFileAsync(proguardFile);
-			await writeFileAsync(
-				proguardFile,
-				mergeContents({
-					tag: `@nozbe/watermelondb/jsi-installation`,
-					src: proguardContents,
-					newSrc: `-keep class com.nozbe.watermelondb.** { *; }`,
-					offset: 0,
-					comment: '#',
-					anchor: /# Add any project specific keep options here:/,
-				}).contents
-			);
+      /**
+       * JSI Step 4: add proguard rules
+       */
+      const proguardFile = path.join(
+        platformProjectRoot,
+        "app/proguard-rules.pro",
+      );
+      const proguardContents = await readFileAsync(proguardFile);
+      await writeFileAsync(
+        proguardFile,
+        mergeContents({
+          tag: `@nozbe/watermelondb/jsi-installation`,
+          src: proguardContents,
+          newSrc: `-keep class com.nozbe.watermelondb.** { *; }`,
+          offset: 0,
+          comment: "#",
+          anchor: /# Add any project specific keep options here:/,
+        }).contents,
+      );
 
-			return config;
-		},
-	]);
+      return config;
+    },
+  ]);
 
 const modifyAndroidApplication: ConfigPlugin = (config) => {
-	return withMainApplication(config, (config) => {
-		const src = addImports(
-			config.modResults.contents,
-			['java.util.Arrays', 'com.facebook.react.bridge.JSIModuleSpec',
-				'com.facebook.react.bridge.JSIModulePackage','com.facebook.react.bridge.ReactApplicationContext',
-				'com.facebook.react.bridge.JavaScriptContextHolder','com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage'],
-			config.modResults.language === 'java',
-		);
+  return withMainApplication(config, (config) => {
+    const src = addImports(
+      config.modResults.contents,
+      [
+        "java.util.Arrays",
+        "com.facebook.react.bridge.JSIModuleSpec",
+        "com.facebook.react.bridge.JSIModulePackage",
+        "com.facebook.react.bridge.ReactApplicationContext",
+        "com.facebook.react.bridge.JavaScriptContextHolder",
+        "com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage",
+      ],
+      config.modResults.language === "java",
+    );
 
-		const moreLinesToAdd = `
+    const moreLinesToAdd = `
 			@Override
 			protected JSIModulePackage getJSIModulePackage() {
 				return new JSIModulePackage() {
@@ -106,19 +120,20 @@ const modifyAndroidApplication: ConfigPlugin = (config) => {
 				};
 			}`;
 
-		config.modResults.contents = mergeContents({
-			src,
-			tag: `@nozbe/watermelondb/jsi-package-tag`,
-			newSrc: `${moreLinesToAdd}`,
-			anchor: /getJSMainModuleName/,
-			offset: -2,
-			comment: '//',
-		}).contents;
+    config.modResults.contents = mergeContents({
+      src,
+      tag: `@nozbe/watermelondb/jsi-package-tag`,
+      newSrc: `${moreLinesToAdd}`,
+      anchor: /getJSMainModuleName/,
+      offset: -2,
+      comment: "//",
+    }).contents;
 
-		return config;
-	})
-}
+    return config;
+  });
+};
 
-export const withAndroidWatermelon: ConfigPlugin = (config) => withPlugins(config, [androidPlugin, modifyAndroidApplication]);
+export const withAndroidWatermelon: ConfigPlugin = (config) =>
+  withPlugins(config, [androidPlugin, modifyAndroidApplication]);
 
 export default withAndroidWatermelon;


### PR DESCRIPTION
hey, thanks for the plugin! 

this PR makes the following changes:

(0) support monorepos by not hardcoding the path to `watermelon-jsi`

(1) remove `iosPlugin` because it can be replaced by `expo-build-properties` as documented in the readme. That's less code for you to maintain and also, given it's using expo-build-properties, it should be more future-proof

(2) to modify `MainApplication.java`, it now uses `withMainApplication` which is a plugin meant for modifying that file. It achieves the same thing but with less code in a less brittle way.

(3) run readme through prettier
(4) run code through prettier

please let me know if you want to change something, thanks!

